### PR TITLE
ci: Seperate linting into a dedicated workflow

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -26,10 +26,3 @@ jobs:
 
       - name: Build
         run: go build -o main 
-
-
-      - name: Run linters and static analysis 
-        run: |
-          go get mvdan.cc/gofumpt 
-          gofumpt -s -w .
-          go vet ./...

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,0 +1,21 @@
+name: Go Lint 
+
+on:
+  push: 
+    brnaches:
+      - main 
+
+jobs: 
+  golangci:
+    - name: lint 
+      runs-on: ubuntu-latest 
+      steps:
+        - uses: action/checkout@v4
+        - uses: actions/setup-go@v4
+          with:
+            go-version: 1.21
+            cache: false 
+        - name: golangci-lint 
+          uses: golangci/golangci-lint-action@v3
+          with:
+            version: latest


### PR DESCRIPTION
- This commit introduces a new GitHub Actions workflow file, go-lint.yml, dedicated to code linting using golangci-lint.
- The linting steps have been removed from the go-ci.yml file to maintain a clear separation of concerns between building and linting.
- Additionally, the go version in the go-lint.yml workflow has been updated to 1.21. This change optimizes the CI setup and ensures that linting is performed independently of the build process.
